### PR TITLE
Hide the editor box outline that browsers add.

### DIFF
--- a/bootstrap-wysiwyg.css
+++ b/bootstrap-wysiwyg.css
@@ -10,7 +10,8 @@
 	box-shadow: rgba(0, 0, 0, 0.0745098) 0px 1px 1px 0px inset;
 	border-top-right-radius: 3px; border-bottom-right-radius: 3px;
 	border-bottom-left-radius: 3px; border-top-left-radius: 3px;
-	overflow:scroll;
+	overflow: scroll;
+	outline: none;
 }
 #voiceBtn {
   width: 20px;


### PR DESCRIPTION
This just adds a simple `outline: none` to the #editor so that it doesn't have a blue outline on it. That outline flashes away when you click an editor button (because of the loss of focus), so this fixes that.
