### PR TITLE
Let the plugin work on .noConflict() pages

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -1,7 +1,7 @@
 /* http://github.com/mindmup/bootstrap-wysiwyg */
 /*global $, FileReader*/
 /*jslint browser:true*/
-$(function () {
+jQuery(function ($) {
 	'use strict';
 	var readFileIntoDataUrl = function (fileInfo) {
 		var loader = $.Deferred(),


### PR DESCRIPTION
If the user has used `jQuery.noConflict()` to yield the global `$` variable to another library or simply make it undefined, the plugin won't currently work. This patch uses `jQuery` externally and the `$` arg passed to the `.ready()` function for its internal jQuery object.
