### PR TITLE
Simplify loop creating toolbars.

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -124,7 +124,7 @@ $(function () {
 		options = $.extend({}, defaultOptions, options);
 		bindHotkeys(options.hotKeys);
 		initFileDrops();
-		$.each($.find('[data-role=' + options.toolbarRole + ']'), function () { bindToolbar($(this), options); });
+		$('[data-role=' + options.toolbarRole + ']').each(function () { bindToolbar($(this), options); });
 		$.each(this, function () {
 			var before,
 				element = $(this);


### PR DESCRIPTION
It would be a good idea to prefix this selector with an element type
such as div if possible, otherwise the selector engine will need to
search all elements in the document for this attribute!
