### PR TITLE
DRY out key event handlers by combining them, and switch to .on().

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -46,16 +46,13 @@ $(function () {
 			},
 			bindHotkeys = function (hotKeys) {
 				$.each(hotKeys, function (hotkey, command) {
-					editor.keydown(hotkey, function (e) {
+					editor.on('keyup keydown', hotkey, function (e) {
 						if (editor.attr('contenteditable') && editor.is(':visible')) {
 							e.preventDefault();
 							e.stopPropagation();
-							execCommand(command);
-						}
-					}).keyup(hotkey, function (e) {
-						if (editor.attr('contenteditable') && editor.is(':visible')) {
-							e.preventDefault();
-							e.stopPropagation();
+							if (e.type === 'keydown' ) {
+								execCommand(command);
+							}
 						}
 					});
 				});


### PR DESCRIPTION
Since `.on()` is used in several places already this code is jQuery 1.7+ so it might as well use `.on()` consistently.
