### PR TITLE
Avoid using $.event.props.

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -111,13 +111,13 @@ $(function () {
 				});
 			},
 			initFileDrops = function () {
-				$.event.props.push('dataTransfer');
-				editor.bind('dragenter dragover', false)
-					.bind('drop', function (e) {
+				editor.on('dragenter dragover', false)
+					.on('drop', function (e) {
+						var dataTransfer = e.originalEvent.dataTransfer;
 						e.stopPropagation();
 						e.preventDefault();
-						if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-							insertFiles(e.dataTransfer.files);
+						if (dataTransfer && dataTransfer.files && dataTransfer.files.length > 0) {
+							insertFiles(dataTransfer.files);
 						}
 					});
 			};


### PR DESCRIPTION
$.event.props adds to a list that jQuery attempts to copy
on every event delivery regardless of the event type, which
can hurt performance. Instead use .originalEvent when needed.
