### PR TITLE
Disable text-selection on editor toolbar

### DIFF
--- a/bootstrap-wysiwyg.css
+++ b/bootstrap-wysiwyg.css
@@ -25,3 +25,10 @@
   box-shadow: none;
   -webkit-box-shadow: none;
 }
+
+div[data-role="editor-toolbar"] {
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}


### PR DESCRIPTION
Prevents the toolbar-items from being selectable by disabling user-select. 
