### PR TITLE
Exposes the default options so they can be overridden.

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -21,26 +21,6 @@ jQuery(function ($) {
 	$.fn.wysiwyg = function (userOptions) {
 		var editor = this,
 			selectedRange,
-			defaultOptions = {
-				hotKeys: {
-					'ctrl+b meta+b': 'bold',
-					'ctrl+i meta+i': 'italic',
-					'ctrl+u meta+u': 'underline',
-					'ctrl+z meta+z': 'undo',
-					'ctrl+y meta+y meta+shift+z': 'redo',
-					'ctrl+l meta+l': 'justifyleft',
-					'ctrl+r meta+r': 'justifyright',
-					'ctrl+e meta+e': 'justifycenter',
-					'ctrl+j meta+j': 'justifyfull',
-					'shift+tab': 'outdent',
-					'tab': 'indent'
-				},
-				toolbarSelector: '[data-role=editor-toolbar]',
-				commandRole: 'edit',
-				activeToolbarClass: 'btn-info',
-				selectionMarker: 'edit-focus-marker',
-				selectionColor: 'darkgrey'
-			},
 			options,
 			updateToolbar = function () {
 				if (options.activeToolbarClass) {
@@ -93,8 +73,8 @@ jQuery(function ($) {
 						selection.removeAllRanges();
 					} catch (ex) {
 						var textRange = document.body.createTextRange();
-                        textRange.select();
-                        document.selection.empty();
+						textRange.select();
+						document.selection.empty();
 					}
 
 					selection.addRange(selectedRange);
@@ -166,7 +146,7 @@ jQuery(function ($) {
 						}
 					});
 			};
-		options = $.extend({}, defaultOptions, userOptions);
+		options = $.extend({}, $.fn.wysiwyg.defaults, userOptions);
 		bindHotkeys(options.hotKeys);
 		initFileDrops();
 		bindToolbar($(options.toolbarSelector), options);
@@ -185,5 +165,25 @@ jQuery(function ($) {
 			}
 		});
 		return this;
+	};
+	$.fn.wysiwyg.defaults = {
+		hotKeys: {
+			'ctrl+b meta+b': 'bold',
+			'ctrl+i meta+i': 'italic',
+			'ctrl+u meta+u': 'underline',
+			'ctrl+z meta+z': 'undo',
+			'ctrl+y meta+y meta+shift+z': 'redo',
+			'ctrl+l meta+l': 'justifyleft',
+			'ctrl+r meta+r': 'justifyright',
+			'ctrl+e meta+e': 'justifycenter',
+			'ctrl+j meta+j': 'justifyfull',
+			'shift+tab': 'outdent',
+			'tab': 'indent'
+		},
+		toolbarSelector: '[data-role=editor-toolbar]',
+		commandRole: 'edit',
+		activeToolbarClass: 'btn-info',
+		selectionMarker: 'edit-focus-marker',
+		selectionColor: 'darkgrey'
 	};
 });


### PR DESCRIPTION
Exposes the default options at $.fn.wysiwyg.defaults so they can be overridden.
