### PR TITLE
Change code to run immediately instead of waiting for dom ready

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -1,7 +1,7 @@
 /* http://github.com/mindmup/bootstrap-wysiwyg */
 /*global jQuery, $, FileReader*/
 /*jslint browser:true*/
-jQuery(function ($) {
+(function ($) {
 	'use strict';
 	var readFileIntoDataUrl = function (fileInfo) {
 		var loader = $.Deferred(),
@@ -186,4 +186,4 @@ jQuery(function ($) {
 		selectionMarker: 'edit-focus-marker',
 		selectionColor: 'darkgrey'
 	};
-});
+}(window.jQuery));


### PR DESCRIPTION
The code does not rely on the dom being ready so do not wait for the dom to be ready before running it.

One use case for this is overriding the defaults. To do this you would have to wait for the dom to be ready and the wysiwyg code to have run. By changing the wysiwyg code to run immediately there is no strange timing issue with this.
