### PR TITLE
Allow for any button type in toolbar by using .btn in selector

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -100,7 +100,7 @@
 				input.data(options.selectionMarker, color);
 			},
 			bindToolbar = function (toolbar, options) {
-				toolbar.find('a[data-' + options.commandRole + ']').click(function () {
+				toolbar.find('.btn[data-' + options.commandRole + ']').click(function () {
 					restoreSelection();
 					editor.focus();
 					execCommand($(this).data(options.commandRole));


### PR DESCRIPTION
Changed bindToolbar selector for finding buttons from a to .btn when listening to click events.

This allows someone to use a `<button>` or an `<a>` tag in their toolbar. This change also makes the two toolbar button selectors in the code match as the updateToolbar method uses .btn and not a:

``` javascript
// in updateToolbar
$(options.toolbarSelector).find('.btn[data-' + options.commandRole + ']').each(function () {
```
