### PR TITLE
Fix for document.execCommand('hiliteColor', ...) throwing error in IE10

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -95,7 +95,9 @@
 			},
 			markSelection = function (input, color) {
 				restoreSelection();
-				document.execCommand('hiliteColor', 0, color || 'transparent');
+				if (document.queryCommandSupported('hiliteColor')) {
+					document.execCommand('hiliteColor', 0, color || 'transparent');
+				}
 				saveSelection();
 				input.data(options.selectionMarker, color);
 			},


### PR DESCRIPTION
Changed the markSelection method to do a check for hilitecolor support before using it.
