### PR TITLE
Added an image-inserted event to the editor

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -85,6 +85,7 @@
 					if (/^image\//.test(fileInfo.type)) {
 						$.when(readFileIntoDataUrl(fileInfo)).done(function (dataUrl) {
 							execCommand('insertimage', dataUrl);
+							editor.trigger('image-inserted');
 						}).fail(function (e) {
 							options.fileUploadError("file-reader", e);
 						});


### PR DESCRIPTION
Added an image-inserted event to the editor. It uses jQuery's trigger on the dom element. I think this would be a better way to do the file upload error callbacks. If they are events then multiple event handlers can be attached at any time instead of once during initialization.
