### PR TITLE
Fix for FF throwing NS_ERROR_UNEXPECTED in updateToolbar

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -27,7 +27,7 @@
 				if (options.activeToolbarClass) {
 					$(options.toolbarSelector).find(toolbarBtnSelector).each(function () {
 						var command = $(this).data(options.commandRole);
-						if (document.queryCommandState(command)) {
+						if (document.queryCommandEnabled(command) && document.queryCommandState(command)) {
 							$(this).addClass(options.activeToolbarClass);
 						} else {
 							$(this).removeClass(options.activeToolbarClass);


### PR DESCRIPTION
Added a check to see if a command is enabled before querying the command's state. This is a fix for the exception FF throws when querying a command state that is disabled. See issue https://github.com/mindmup/bootstrap-wysiwyg/issues/23

I read through some of the spec for rich text editing and it states that a command can be enabled or disabled at any given time. When no text is selected on the page some of the commands become disabled. For example the insertunorderedlist command is disabled. document.queryCommandEnabled can be used to check for this condition. The spec does not specify what should happen if document.queryCommandState is called on a disabled command and that the browsers do different things from throwing exceptions to returning false or an empty string. With that in mind there are two ways to fix this. You can add a try/catch for FF (which throws an exception) but you might catch other types of errors so that isn't a good solution. I went with checking the enabled state of the command manually because it reduces the overhead of handling an exception and doesn't hide errors. It also matches the looseness of the spec in this area.
