### PR TITLE
Toolbar Fixes

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -29,8 +29,8 @@
 						var commandArr = $(this).data(options.commandRole).split(' '),
 							command = commandArr[0];
 
-						// If the command has an argument and its value matches this button
-						if (commandArr.length > 1 && document.queryCommandEnabled(command) && document.queryCommandValue(command) === commandArr[1]) {
+						// If the command has an argument and its value matches this button. == used for string/number comparison
+						if (commandArr.length > 1 && document.queryCommandEnabled(command) && document.queryCommandValue(command) == commandArr[1]) {
 							$(this).addClass(options.activeToolbarClass);
 						// Else if the command has no arguments and it is active
 						} else if (commandArr.length === 1 && document.queryCommandEnabled(command) && document.queryCommandState(command)) {


### PR DESCRIPTION
Fix for FF throwing NS_ERROR_UNEXPECTED in updateToolbar (issue https://github.com/mindmup/bootstrap-wysiwyg/issues/23)
Adds support for commands with arguments in the toolbar and also is a fix for issue https://github.com/mindmup/bootstrap-wysiwyg/issues/56#issuecomment-18285445

My other pull request https://github.com/mindmup/bootstrap-wysiwyg/pull/66 fixed the FF error. This pull request includes that fix and a fix for the IE10 issue.
## 

Added a check to see if a command is enabled before querying the command's state. This is a fix for the exception FF throws when querying a command state that is disabled.

I read through some of the spec for rich text editing and it states that a command can be enabled or disabled at any given time. When no text is selected on the page some of the commands become disabled. For example the insertunorderedlist command is disabled. document.queryCommandEnabled can be used to check for this condition. The spec does not specify what should happen if document.queryCommandState is called on a disabled command and that the browsers do different things from throwing exceptions to returning false or an empty string. With that in mind there are two ways to fix this. You can add a try/catch for FF (which throws an exception) but you might catch other types of errors so that isn't a good solution. I went with checking the enabled state of the command manually because it reduces the overhead of handling an exception and doesn't hide errors. It also matches the looseness of the spec in this area.
## 

The other change that adds support for commands with arguments simply checks to see if the command has arguments and if so uses document.queryCommandValue to determine if the command is active.
