### PR TITLE
Bold / Italic / Strike / Underline buttons don't work correctly

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -56,7 +56,13 @@
 				if (options.activeToolbarClass) {
 					$(options.toolbarSelector).find(toolbarBtnSelector).each(function () {
 						var command = $(this).data(options.commandRole);
-						var commandNoArgs = command.slice(0, command.indexOf(' '));
+						var commandNoArgs; // Temporarily store index, replace with command.
+
+						if ((commandNoArgs = command.indexOf(' ')) >= 0) {
+							commandNoArgs = command.slice(0, commandNoArgs);
+						} else {
+							commandNoArgs = command;
+						}
 						if (document.queryCommandState(command)) {
 							$(this).addClass(options.activeToolbarClass);
 						} else if (commandNoArgs + ' ' + document.queryCommandValue(commandNoArgs) === command) {


### PR DESCRIPTION
- Fixes #19
- Problem: addRange or removeAllRanges kills the browser command states.
- Store cache in commandCache
- Add updateCommandCache and restoreCommandCache methods
- Add support for command-with-arg buttons to be in an active state
- Update command cache when running execCommand
- Store and then update selected commands when selecting a toolbar button
- Create the command cache by looking up the buttons that are in the DOM, set the default value to false
