### PR TITLE
Fix hotkey support, add event namespaces, add hotkey enable callback

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -116,12 +116,16 @@
 				var commandArr = commandWithArgs.split(' '),
 					command = commandArr.shift(),
 					args = commandArr.join(' ') + (valueArg || '');
+				if (command.indexOf('justify') === 0) {
+					['left', 'center', 'right'].forEach(function(val) { commandCache['justify' + val] = false; });
+				}
 				document.execCommand(command, 0, args);
 				if (args.length > 0) {
 					commandCache[command] = document.queryCommandValue(command);
 				} else {
 					commandCache[command] = document.queryCommandState(command);
 				}
+				restoreCommandCache();
 				updateToolbar();
 			},
 			mapHotKeyToCommand = function (event, hotKeys) {


### PR DESCRIPTION
## Depends on #76
- Map multiple hotkeys in a string into single hotkey commands
- Store them in a hash
- When buttons are pressed (`keydown`), compute a string to match them on
- They must match this format:
  - Keys must come in order of modifiers as shown below:
  - `<CTRL>+(<SHIFT>+)<KEY> (shift optional)`
  - `<META>+(<SHIFT>+)<KEY>`
  - `<ALT>+(<SHIFT>+)<KEY>`
  - `<SHIFT>+<KEY>`
  - `<KEY> (i.e. tab)`
- Change `bindHotKeys` to only bind single events for `keydown` and `keyup`
- Re-map the keys into a hash as mentioned above
- Prevent propagation and default if we match a command we're allowed
- Add callback option to test a hotkey to see if it's allowed.
- Add `namsepaceEvents` helper, to create all events with a namespace
- Add default callback for `hotKeyEnabledCallback`
  - returns `true` if a hotkey can execute  browser command
  - takes parameter `command`. i.e. `bold`
