### PR TITLE
CSS cleanup

### DIFF
--- a/index.css
+++ b/index.css
@@ -6,12 +6,12 @@
 	max-height: 250px;
 	height: 250px;
 	background-color: white;
-	border-collapse: separate; 
-	border: 1px solid rgb(204, 204, 204); 
-	padding: 4px; 
-	box-sizing: content-box; 
-	-webkit-box-shadow: rgba(0, 0, 0, 0.0745098) 0px 1px 1px 0px inset; 
-	box-shadow: rgba(0, 0, 0, 0.0745098) 0px 1px 1px 0px inset;
+	border-collapse: separate;
+	border: 1px solid rgb(204, 204, 204);
+	padding: 4px;
+	box-sizing: content-box;
+	-webkit-box-shadow: rgba(0, 0, 0, 0.0745098) 0 1px 1px 0 inset;
+	box-shadow: rgba(0, 0, 0, 0.0745098) 0 1px 1px 0 inset;
 	border-top-right-radius: 3px; border-bottom-right-radius: 3px;
 	border-bottom-left-radius: 3px; border-top-left-radius: 3px;
 	overflow: scroll;


### PR DESCRIPTION
Removes unneccessary px declaration from values set to 0 in css
Trims trailing white space
