### PR TITLE
Fixed formatBlock buttons being not highlighted in the toolbar

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -26,8 +26,9 @@
 			updateToolbar = function () {
 				if (options.activeToolbarClass) {
 					$(options.toolbarSelector).find(toolbarBtnSelector).each(function () {
-						var command = $(this).data(options.commandRole);
-						if (document.queryCommandState(command)) {
+						var command = $(this).data(options.commandRole),
+							format = command.match(/formatBlock (.+)/);
+						if (document.queryCommandState(command) || (format && (format[1] == document.queryCommandValue("formatBlock")))) {
 							$(this).addClass(options.activeToolbarClass);
 						} else {
 							$(this).removeClass(options.activeToolbarClass);


### PR DESCRIPTION
The current version of bootstrap-wysiwyg allows you to add "formatBlock" buttons ("P", "H1", "H2", ...) to the toolbar manually. However, the toolbar never highlight such buttons.

This pull request fixes the problem.
