### PR TITLE
Fix for IE not understanding commands with parameters

### DIFF
--- a/bootstrap-wysiwyg.js
+++ b/bootstrap-wysiwyg.js
@@ -26,11 +26,13 @@
 			updateToolbar = function () {
 				if (options.activeToolbarClass) {
 					$(options.toolbarSelector).find(toolbarBtnSelector).each(function () {
-						var command = $(this).data(options.commandRole);
-						if (document.queryCommandState(command)) {
-							$(this).addClass(options.activeToolbarClass);
-						} else {
-							$(this).removeClass(options.activeToolbarClass);
+						var command = $(this).data(options.commandRole).split(' ')[0];
+						if (document.queryCommandSupported(command)) {
+							if (document.queryCommandState(command)) {
+								$(this).addClass(options.activeToolbarClass);
+							} else {
+								$(this).removeClass(options.activeToolbarClass);
+							}
 						}
 					});
 				}


### PR DESCRIPTION
I found that IE does not understand commands with parameters (such as "fontSize 3").

This fix strips off any parameters and also does a check to make sure the browser supports the command before it tries to query the state of the command.

This is a little more generic than some of the other issue solutions which were only looking at fixing specific command problems.
